### PR TITLE
README - Update the nixpkgs version used in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Use the output `overlays.hspkgs`, for example in your flake:
 {
   inputs = {
     nixpkgs.url =
-      "github:NixOS/nixpkgs/d46be5b0e8baad998f8277e04370f0fd30dde11b";
+      "github:NixOS/nixpkgs/0dcf2ad93d93d0cba20f8517689267abc33014a6";
     hspkgs.url = "github:podenv/hspkgs";
   };
 


### PR DESCRIPTION
This changes the nixpkgs version used in the example to avoid the following issue:

```
$ nix develop
warning: Git tree '/home/fedora/git/github.com/haskell-boilerplate' is dirty
warning: creating lock file '/home/fedora/git/github.com/haskell-boilerplate/flake.lock'
warning: Git tree '/home/fedora/git/github.com/haskell-boilerplate' is dirty
error: attribute 'ghc925' missing

       at /nix/store/bhi6c17s5pc23bs43jqxkl53jgv4vgdf-source/flake.nix:150:20:

          149|           mk-exe = prev.haskell.lib.justStaticExecutables;
          150|           hspkgs = prev.haskell.packages.${compiler}.override haskellOverrides;
             |                    ^
          151|           hls = prev.haskell-language-server.override {
       Did you mean one of ghc923 or ghc902?
```